### PR TITLE
improved elasticsearch5 support

### DIFF
--- a/haystack/backends/elasticsearch5_backend.py
+++ b/haystack/backends/elasticsearch5_backend.py
@@ -138,12 +138,6 @@ class Elasticsearch5SearchBackend(ElasticsearchSearchBackend):
 
         filters = []
 
-        if fields:
-            if isinstance(fields, (list, set)):
-                fields = " ".join(fields)
-
-            kwargs["stored_fields"] = fields
-
         if sort_by is not None:
             order_list = []
             for field, direction in sort_by:

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -580,7 +580,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             exclude_fields = []
             for field in fields:
                 if field.startswith('-'):
-                    exclude_fields.append(field.replace('-', ''))
+                    exclude_fields.append(field.replace('-', '', 1))
                 else:
                     include_fields.append(field)
 


### PR DESCRIPTION
Add django_ct model type filtering for elasticsearch5_backend. Fix the server-vs-local mapping comparison logic so it doesn't always try to update the mapping. Allow for specifying a 'dynamic' mapping setting in HAYSTACK_CONNECTIONS.