### PR TITLE
ARCH-3196: add support for explicit source field inclusion/exclusion

### DIFF
--- a/haystack/backends/elasticsearch5_backend.py
+++ b/haystack/backends/elasticsearch5_backend.py
@@ -138,12 +138,6 @@ class Elasticsearch5SearchBackend(ElasticsearchSearchBackend):
 
         filters = []
 
-        if fields:
-            if isinstance(fields, (list, set)):
-                fields = " ".join(fields)
-
-            kwargs["stored_fields"] = fields
-
         if sort_by is not None:
             order_list = []
             for field, direction in sort_by:

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -580,7 +580,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             exclude_fields = []
             for field in fields:
                 if field.startswith('-'):
-                    exclude_fields.append(field.replace('-', ''))
+                    exclude_fields.append(field.replace('-', '', 1))
                 else:
                     include_fields.append(field)
 


### PR DESCRIPTION
elasticsearch supports telling it which 'source'  the json body of the indexed record) fields to include/exclude in the response. For bulk order with large #s of distinct values for cert-related fields the actual size of the data across the wire can get very large. This will allow us to exclude fields we don't actually care about for order exports.